### PR TITLE
Handle enclave errors using C++ exceptions rethrown to Java

### DIFF
--- a/src/enclave/App/App.cpp
+++ b/src/enclave/App/App.cpp
@@ -381,7 +381,7 @@ void ocall_exit(int exit_code) {
 void ocall_throw(const char *message) {
   JNIEnv* env;
   jvm->AttachCurrentThread((void**) &env, NULL);
-  jclass exception = env->FindClass("java/lang/Exception");
+  jclass exception = env->FindClass("edu/berkeley/cs/rise/opaque/OpaqueException");
   env->ThrowNew(exception, message);
 }
 

--- a/src/enclave/App/App.cpp
+++ b/src/enclave/App/App.cpp
@@ -366,18 +366,23 @@ void ocall_free(uint8_t *buf) {
 }
 
 void ocall_exit(int exit_code) {
+  std::exit(exit_code);
+}
+
+/**
+ * Throw a Java exception with the specified message.
+ *
+ * This function is intended to be invoked from an ecall that was in turn invoked by a JNI method.
+ * As a result of calling this function, the JNI method will throw a Java exception upon its return.
+ *
+ * Important: Note that this function will return to the caller. The exception is only thrown at the
+ * end of the JNI method invocation.
+ */
+void ocall_throw(const char *message) {
   JNIEnv* env;
-  // printf("JVM: %p\n", jvm);
   jvm->AttachCurrentThread((void**) &env, NULL);
-
-  char exBuffer[50];
-  sprintf(exBuffer, "Enclave exited with exit code %i", exit_code);
-  // printf("do i make it here3\n");
   jclass exception = env->FindClass("java/lang/Exception");
-  env->ThrowNew(exception, exBuffer);
-  // printf("exit code: %i\n", exit_code);
-  // std::exit(exit_code);
-
+  env->ThrowNew(exception, message);
 }
 
 #if defined(_MSC_VER)

--- a/src/enclave/Common/common.h
+++ b/src/enclave/Common/common.h
@@ -29,14 +29,6 @@ namespace std {
 #define perf(...) do {} while (0)
 #endif
 
-#define check(test, ...) do {                   \
-    bool result = test;                         \
-    if (!result) {                              \
-      printf(__VA_ARGS__);                      \
-      std::exit(1);                                  \
-    }                                           \
-  } while (0)
-
 inline int memcpy_s(void *dest,
                     size_t numberOfElements,
                     const void *src,

--- a/src/enclave/Enclave/Aggregate.cpp
+++ b/src/enclave/Enclave/Aggregate.cpp
@@ -67,15 +67,21 @@ void non_oblivious_aggregate_step2(
     prev_partition_last_row, prev_partition_last_row_length);
   FlatbuffersRowWriter w;
 
-  check(next_partition_first_row_reader.num_rows() <= 1,
-        "Incorrect number of starting rows from next partition passed: expected 0 or 1, got %d\n",
-        next_partition_first_row_reader.num_rows());
-  check(prev_partition_last_group_reader.num_rows() <= 1,
-        "Incorrect number of ending groups from prev partition passed: expected 0 or 1, got %d\n",
-        prev_partition_last_group_reader.num_rows());
-  check(prev_partition_last_row_reader.num_rows() <= 1,
-        "Incorrect number of ending rows from prev partition passed: expected 0 or 1, got %d\n",
-        prev_partition_last_row_reader.num_rows());
+  if (next_partition_first_row_reader.num_rows() > 1) {
+      throw std::runtime_error(
+          std::string("Incorrect number of starting rows from next partition passed: expected 0 or 1, got ")
+          + std::to_string(next_partition_first_row_reader.num_rows()));
+  }
+  if (prev_partition_last_group_reader.num_rows() > 1) {
+      throw std::runtime_error(
+          std::string("Incorrect number of ending groups from prev partition passed: expected 0 or 1, got ")
+          + std::to_string(prev_partition_last_group_reader.num_rows()));
+  }
+  if (prev_partition_last_row_reader.num_rows() > 1) {
+      throw std::runtime_error(
+          std::string("Incorrect number of ending rows from prev partition passed: expected 0 or 1, got ")
+          + std::to_string(prev_partition_last_row_reader.num_rows()));
+  }
 
   const tuix::Row *next_partition_first_row_ptr =
     next_partition_first_row_reader.has_next() ? next_partition_first_row_reader.next() : nullptr;

--- a/src/enclave/Enclave/Enclave.cpp
+++ b/src/enclave/Enclave/Enclave.cpp
@@ -10,57 +10,87 @@
 #include "Project.h"
 #include "Sort.h"
 #include "isv_enclave.h"
+#include "util.h"
+
+// This file contains definitions of the ecalls declared in Enclave.edl. Errors originating within
+// these ecalls are signaled by throwing a std::runtime_error, which is caught at the top level of
+// the ecall (i.e., within these definitions), and are then rethrown as Java exceptions using
+// ocall_throw.
 
 void ecall_encrypt(uint8_t *plaintext, uint32_t plaintext_length,
                    uint8_t *ciphertext, uint32_t cipher_length) {
-  // IV (12 bytes) + ciphertext + mac (16 bytes)
-  assert(cipher_length >= plaintext_length + SGX_AESGCM_IV_SIZE + SGX_AESGCM_MAC_SIZE);
-  (void)cipher_length;
-  (void)plaintext_length;
-  encrypt(plaintext, plaintext_length, ciphertext);
+  try {
+    // IV (12 bytes) + ciphertext + mac (16 bytes)
+    assert(cipher_length >= plaintext_length + SGX_AESGCM_IV_SIZE + SGX_AESGCM_MAC_SIZE);
+    (void)cipher_length;
+    (void)plaintext_length;
+    encrypt(plaintext, plaintext_length, ciphertext);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_decrypt(uint8_t *ciphertext,
                    uint32_t ciphertext_length,
                    uint8_t *plaintext,
                    uint32_t plaintext_length) {
-  // IV (12 bytes) + ciphertext + mac (16 bytes)
-  assert(ciphertext_length >= plaintext_length + SGX_AESGCM_IV_SIZE + SGX_AESGCM_MAC_SIZE);
-  (void)ciphertext_length;
-  (void)plaintext_length;
-  decrypt(ciphertext, ciphertext_length, plaintext);
+  try {
+    // IV (12 bytes) + ciphertext + mac (16 bytes)
+    assert(ciphertext_length >= plaintext_length + SGX_AESGCM_IV_SIZE + SGX_AESGCM_MAC_SIZE);
+    (void)ciphertext_length;
+    (void)plaintext_length;
+    decrypt(ciphertext, ciphertext_length, plaintext);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_project(uint8_t *condition, size_t condition_length,
                    uint8_t *input_rows, size_t input_rows_length,
                    uint8_t **output_rows, size_t *output_rows_length) {
-  project(condition, condition_length,
-          input_rows, input_rows_length,
-          output_rows, output_rows_length);
+  try {
+    project(condition, condition_length,
+            input_rows, input_rows_length,
+            output_rows, output_rows_length);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_filter(uint8_t *condition, size_t condition_length,
                   uint8_t *input_rows, size_t input_rows_length,
                   uint8_t **output_rows, size_t *output_rows_length) {
-  filter(condition, condition_length,
-         input_rows, input_rows_length,
-         output_rows, output_rows_length);
+  try {
+    filter(condition, condition_length,
+           input_rows, input_rows_length,
+           output_rows, output_rows_length);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_sample(uint8_t *input_rows, size_t input_rows_length,
                   uint8_t **output_rows, size_t *output_rows_length) {
-  sample(input_rows, input_rows_length,
-         output_rows, output_rows_length);
+  try {
+    sample(input_rows, input_rows_length,
+           output_rows, output_rows_length);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_find_range_bounds(uint8_t *sort_order, size_t sort_order_length,
                              uint32_t num_partitions,
                              uint8_t *input_rows, size_t input_rows_length,
                              uint8_t **output_rows, size_t *output_rows_length) {
-  find_range_bounds(sort_order, sort_order_length,
-                    num_partitions,
-                    input_rows, input_rows_length,
-                    output_rows, output_rows_length);
+  try {
+    find_range_bounds(sort_order, sort_order_length,
+                      num_partitions,
+                      input_rows, input_rows_length,
+                      output_rows, output_rows_length);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_partition_for_sort(uint8_t *sort_order, size_t sort_order_length,
@@ -68,37 +98,53 @@ void ecall_partition_for_sort(uint8_t *sort_order, size_t sort_order_length,
                               uint8_t *input_rows, size_t input_rows_length,
                               uint8_t *boundary_rows, size_t boundary_rows_length,
                               uint8_t **output_partitions, size_t *output_partition_lengths) {
-  partition_for_sort(sort_order, sort_order_length,
-                     num_partitions,
-                     input_rows, input_rows_length,
-                     boundary_rows, boundary_rows_length,
-                     output_partitions, output_partition_lengths);
+  try {
+    partition_for_sort(sort_order, sort_order_length,
+                       num_partitions,
+                       input_rows, input_rows_length,
+                       boundary_rows, boundary_rows_length,
+                       output_partitions, output_partition_lengths);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_external_sort(uint8_t *sort_order, size_t sort_order_length,
                          uint8_t *input_rows, size_t input_rows_length,
                          uint8_t **output_rows, size_t *output_rows_length) {
-  external_sort(sort_order, sort_order_length,
-                input_rows, input_rows_length,
-                output_rows, output_rows_length);
+  try {
+    external_sort(sort_order, sort_order_length,
+                  input_rows, input_rows_length,
+                  output_rows, output_rows_length);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_scan_collect_last_primary(uint8_t *join_expr, size_t join_expr_length,
                                      uint8_t *input_rows, size_t input_rows_length,
                                      uint8_t **output_rows, size_t *output_rows_length) {
-  scan_collect_last_primary(join_expr, join_expr_length,
-                            input_rows, input_rows_length,
-                            output_rows, output_rows_length);
+  try {
+    scan_collect_last_primary(join_expr, join_expr_length,
+                              input_rows, input_rows_length,
+                              output_rows, output_rows_length);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_non_oblivious_sort_merge_join(uint8_t *join_expr, size_t join_expr_length,
                                          uint8_t *input_rows, size_t input_rows_length,
                                          uint8_t *join_row, size_t join_row_length,
                                          uint8_t **output_rows, size_t *output_rows_length) {
-  non_oblivious_sort_merge_join(join_expr, join_expr_length,
-                                input_rows, input_rows_length,
-                                join_row, join_row_length,
-                                output_rows, output_rows_length);
+  try {
+    non_oblivious_sort_merge_join(join_expr, join_expr_length,
+                                  input_rows, input_rows_length,
+                                  join_row, join_row_length,
+                                  output_rows, output_rows_length);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_non_oblivious_aggregate_step1(
@@ -107,12 +153,16 @@ void ecall_non_oblivious_aggregate_step1(
   uint8_t **first_row, size_t *first_row_length,
   uint8_t **last_group, size_t *last_group_length,
   uint8_t **last_row, size_t *last_row_length) {
-  non_oblivious_aggregate_step1(
-    agg_op, agg_op_length,
-    input_rows, input_rows_length,
-    first_row, first_row_length,
-    last_group, last_group_length,
-    last_row, last_row_length);
+  try {
+    non_oblivious_aggregate_step1(
+      agg_op, agg_op_length,
+      input_rows, input_rows_length,
+      first_row, first_row_length,
+      last_group, last_group_length,
+      last_row, last_row_length);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 void ecall_non_oblivious_aggregate_step2(
@@ -122,35 +172,56 @@ void ecall_non_oblivious_aggregate_step2(
   uint8_t *prev_partition_last_group, size_t prev_partition_last_group_length,
   uint8_t *prev_partition_last_row, size_t prev_partition_last_row_length,
   uint8_t **output_rows, size_t *output_rows_length) {
-  non_oblivious_aggregate_step2(
-    agg_op, agg_op_length,
-    input_rows, input_rows_length,
-    next_partition_first_row, next_partition_first_row_length,
-    prev_partition_last_group, prev_partition_last_group_length,
-    prev_partition_last_row, prev_partition_last_row_length,
-    output_rows, output_rows_length);
+  try {
+    non_oblivious_aggregate_step2(
+      agg_op, agg_op_length,
+      input_rows, input_rows_length,
+      next_partition_first_row, next_partition_first_row_length,
+      prev_partition_last_group, prev_partition_last_group_length,
+      prev_partition_last_row, prev_partition_last_row_length,
+      output_rows, output_rows_length);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 sgx_status_t ecall_enclave_init_ra(int b_pse, sgx_ra_context_t *p_context) {
-  return enclave_init_ra(b_pse, p_context);
+  try {
+    return enclave_init_ra(b_pse, p_context);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+    return SGX_ERROR_UNEXPECTED;
+  }
 }
 
 
 void ecall_enclave_ra_close(sgx_ra_context_t context) {
-  enclave_ra_close(context);
+  try {
+    enclave_ra_close(context);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+  }
 }
 
 sgx_status_t ecall_verify_att_result_mac(sgx_ra_context_t context, uint8_t* message,
                                          size_t message_size, uint8_t* mac,
                                          size_t mac_size) {
-
-  return verify_att_result_mac(context, message, message_size, mac, mac_size);
+  try {
+    return verify_att_result_mac(context, message, message_size, mac, mac_size);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+    return SGX_ERROR_UNEXPECTED;
+  }
 }
 
 sgx_status_t ecall_put_secret_data(sgx_ra_context_t context,
                                    uint8_t* p_secret,
                                    uint32_t secret_size,
                                    uint8_t* gcm_mac) {
-
-  return put_secret_data(context, p_secret, secret_size, gcm_mac);
+  try {
+    return put_secret_data(context, p_secret, secret_size, gcm_mac);
+  } catch (const std::runtime_error &e) {
+    ocall_throw(e.what());
+    return SGX_ERROR_UNEXPECTED;
+  }
 }

--- a/src/enclave/Enclave/Enclave.edl
+++ b/src/enclave/Enclave/Enclave.edl
@@ -95,6 +95,7 @@ enclave {
     void ocall_malloc(size_t size, [out] uint8_t **ret);
     void ocall_free([user_check] uint8_t *buf);
     void ocall_exit(int exit_code);
+    void ocall_throw([in, string] const char *message);
   };
 
 };

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -48,10 +48,9 @@ std::string to_string(const tuix::Field *f) {
   case tuix::FieldUnion_MapField:
     return to_string(f->value_as_MapField());
   default:
-    printf("to_string(tuix::Field): Unknown field type %d\n",
-           f->value_type());
-    std::exit(1);
-    return "";
+    throw std::runtime_error(
+      std::string("to_string(tuix::Field): Unknown field type ")
+      + std::to_string(f->value_type()));
   }
 }
 
@@ -280,9 +279,8 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
   //     is_null);
   // }
   default:
-    printf("flatbuffers_copy tuix::Field: Unknown field type %d\n",
-           field->value_type());
-    std::exit(1);
-    return flatbuffers::Offset<tuix::Field>();
+    throw std::runtime_error(
+      std::string("flatbuffers_copy tuix::Field: Unknown field type ")
+                  + std::to_string(field->value_type()));
   }
 }

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -246,6 +246,18 @@ flatbuffers::Offset<tuix::Field> flatbuffers_copy(
         builder,
         static_cast<const tuix::DateField *>(field->value())->value()).Union(),
       is_null);
+  case tuix::FieldUnion_CalendarIntervalField:
+  {
+    auto cif = static_cast<const tuix::CalendarIntervalField *>(field->value());
+    return tuix::CreateField(
+      builder,
+      tuix::FieldUnion_CalendarIntervalField,
+      tuix::CreateCalendarIntervalField(
+        builder,
+        cif->months(),
+        cif->microseconds()).Union(),
+      is_null);
+  }
   case tuix::FieldUnion_ArrayField:
   {
     auto array_field = static_cast<const tuix::ArrayField *>(field->value());

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -98,7 +98,7 @@ std::string to_string(const tuix::ByteField *f) {
 
 std::string to_string(const tuix::CalendarIntervalField *f) {
   (void)f;
-  throw "Can't convert CalendarIntervalField to string";
+  throw std::runtime_error("Can't convert CalendarIntervalField to string");
 }
 
 std::string to_string(const tuix::NullField *f) {

--- a/src/enclave/Enclave/Project.cpp
+++ b/src/enclave/Enclave/Project.cpp
@@ -7,8 +7,11 @@ void project(uint8_t *project_list, size_t project_list_length,
              uint8_t *input_rows, size_t input_rows_length,
              uint8_t **output_rows, size_t *output_rows_length) {
   flatbuffers::Verifier v(project_list, project_list_length);
-  check(v.VerifyBuffer<tuix::ProjectExpr>(nullptr),
-        "Corrupt ProjectExpr %p of length %d\n", project_list, project_list_length);
+  if (!v.VerifyBuffer<tuix::ProjectExpr>(nullptr)) {
+      throw std::runtime_error(
+          std::string("Corrupt ProjectExpr buffer of length ")
+          + std::to_string(project_list_length));
+  }
 
   // Create a vector of expression evaluators, one per output column
   const tuix::ProjectExpr* project_expr =

--- a/src/enclave/Enclave/isv_enclave.cpp
+++ b/src/enclave/Enclave/isv_enclave.cpp
@@ -34,6 +34,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <stdexcept>
 
 #include <sgx_tcrypto.h>
 #include <sgx_tkey_exchange.h>
@@ -218,8 +219,7 @@ sgx_status_t enclave_init_ra(int b_pse,
     ret = sgx_ecc256_open_context(&ecc_state);
     if (ret != SGX_SUCCESS) {
         if (SGX_ERROR_OUT_OF_MEMORY != ret) {
-          printf("SGX out of memory\n");
-          std::exit(1);
+          throw std::runtime_error("SGX out of memory");
         }
         printf("SGX ecc256 open context failure\n");
         return ret;
@@ -229,8 +229,7 @@ sgx_status_t enclave_init_ra(int b_pse,
                                  ecc_state, &valid);
     if (ret != SGX_SUCCESS) {
       if (ret != SGX_ERROR_OUT_OF_MEMORY) {
-        printf("SGX out of memory 2\n");
-        std::exit(1);
+        throw std::runtime_error("SGX out of memory 2");
       }
       sgx_ecc256_close_context(ecc_state);
       return ret;
@@ -238,8 +237,7 @@ sgx_status_t enclave_init_ra(int b_pse,
 
     if (!valid) {
       sgx_ecc256_close_context(ecc_state);
-      printf("pub_key points invalid\n");
-      std::exit(1);
+      throw std::runtime_error("pub_key points invalid");
     }
     sgx_ecc256_close_context(ecc_state);
 

--- a/src/enclave/ServiceProvider/service_provider.cpp
+++ b/src/enclave/ServiceProvider/service_provider.cpp
@@ -41,6 +41,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <time.h>
+#include <stdexcept>
 
 #ifndef SAFE_FREE
 #define SAFE_FREE(ptr) {if (NULL != (ptr)) {free(ptr); (ptr) = NULL;}}
@@ -142,9 +143,12 @@ int read_secret_key(const char *filename,
 
   int ret = 0;
   FILE *secret_key_file = fopen(filename, "r");
-  check(secret_key_file != nullptr,
-        "Error: Private key file '%s' does not exist. Set environment variable "
-        "$PRIVATE_KEY_PATH.\n", filename);
+  if (secret_key_file == nullptr) {
+      throw std::runtime_error(
+          std::string("Error: Private key file '")
+          + std::string(filename)
+          + std::string("' does not exist. Set environment variable $PRIVATE_KEY_PATH."));
+  }
   EVP_PKEY *pkey = PEM_read_PrivateKey(secret_key_file, NULL, NULL, NULL);
   if (pkey == NULL) {
     printf("[read_secret_key] returned private key is null\n");

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/OpaqueException.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/OpaqueException.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.rise.opaque
+
+/** Represents an exception originating from an Opaque enclave. */
+class OpaqueException(message: String) extends Exception(message) {
+  def this(message: String, cause: Throwable) {
+    this(message)
+    initCause(cause)
+  }
+
+  def this(cause: Throwable) {
+    this(Option(cause).map(_.toString).orNull, cause)
+
+  }
+
+  def this() {
+    this(null: String)
+  }
+}


### PR DESCRIPTION
Enclave errors are currently signaled using `ocall_exit()` (often invoked using
the `check()` macro). This quits the entire JVM process including the Spark
worker or driver, which is not user-friendly.

JNI provides a way to throw Java exceptions, but the corresponding JNI
call (`JNIEnv::ThrowNew()`) only throws the Java exception once the JNI method
invocation returns. That is, `ThrowNew()` returns to the caller, which is
presumably in a corrupt state and cannot continue normal execution. This
prevents `ThrowNew()` from being used as a direct replacement for
`ocall_exit()`.

Instead, this commit uses C++ exceptions within the enclave to transfer control
flow to a handler at the top level of each ecall. The handler invokes
`ThrowNew()` (via `ocall_throw()`, a newly-introduced function) and directly
returns from the ecall.

Since it is no longer desirable to use `ocall_exit()`, this commit also removes
the `check()` macro and replaces all uses of it with C++ exception throws.
It leaves `ocall_exit()` in case it is useful in the future.