### PR TITLE
Match enclave AES-GCM format with Java crypto format

### DIFF
--- a/src/enclave/Enclave/Crypto.cpp
+++ b/src/enclave/Enclave/Crypto.cpp
@@ -37,15 +37,16 @@ void encrypt(uint8_t *plaintext, uint32_t plaintext_length,
   // one buffer to store IV (12 bytes) + ciphertext + mac (16 bytes)
 
   uint8_t *iv_ptr = ciphertext;
+  uint8_t *ciphertext_ptr = ciphertext + SGX_AESGCM_IV_SIZE;
+  sgx_aes_gcm_128bit_tag_t *mac_ptr =
+    (sgx_aes_gcm_128bit_tag_t *) (ciphertext + SGX_AESGCM_IV_SIZE + plaintext_length);
+
   // generate random IV
   sgx_read_rand(iv_ptr, SGX_AESGCM_IV_SIZE);
-  sgx_aes_gcm_128bit_tag_t *mac_ptr = (sgx_aes_gcm_128bit_tag_t *) (ciphertext + SGX_AESGCM_IV_SIZE);
-  uint8_t *ciphertext_ptr = ciphertext + SGX_AESGCM_IV_SIZE + SGX_AESGCM_MAC_SIZE;
 
   AesGcm cipher(ks, iv_ptr, SGX_AESGCM_IV_SIZE);
   cipher.encrypt(plaintext, plaintext_length, ciphertext_ptr, plaintext_length);
   memcpy(mac_ptr, cipher.tag().t, SGX_AESGCM_MAC_SIZE);
-  
 }
 
 
@@ -66,8 +67,9 @@ void decrypt(const uint8_t *ciphertext, uint32_t ciphertext_length,
   uint32_t plaintext_length = ciphertext_length - SGX_AESGCM_IV_SIZE - SGX_AESGCM_MAC_SIZE;
 
   uint8_t *iv_ptr = (uint8_t *) ciphertext;
-  sgx_aes_gcm_128bit_tag_t *mac_ptr = (sgx_aes_gcm_128bit_tag_t *) (ciphertext + SGX_AESGCM_IV_SIZE);
-  uint8_t *ciphertext_ptr = (uint8_t *) (ciphertext + SGX_AESGCM_IV_SIZE + SGX_AESGCM_MAC_SIZE);
+  uint8_t *ciphertext_ptr = (uint8_t *) (ciphertext + SGX_AESGCM_IV_SIZE);
+  sgx_aes_gcm_128bit_tag_t *mac_ptr =
+    (sgx_aes_gcm_128bit_tag_t *) (ciphertext + SGX_AESGCM_IV_SIZE + plaintext_length);
 
   AesGcm decipher(ks, iv_ptr, SGX_AESGCM_IV_SIZE);
   decipher.decrypt(ciphertext_ptr, plaintext_length, plaintext, plaintext_length);

--- a/src/enclave/Enclave/Crypto.cpp
+++ b/src/enclave/Enclave/Crypto.cpp
@@ -30,7 +30,7 @@ void encrypt(uint8_t *plaintext, uint32_t plaintext_length,
 
   initKeySchedule();
 
-  // key size is 12 bytes/128 bits
+  // key size is 16 bytes/128 bits
   // IV size is 12 bytes/96 bits
   // MAC size is 16 bytes/128 bits
 
@@ -58,7 +58,7 @@ void decrypt(const uint8_t *ciphertext, uint32_t ciphertext_length,
   // decrypt using a global key
   // TODO: fix this; should use key obtained from client
 
-  // key size is 12 bytes/128 bits
+  // key size is 16 bytes/128 bits
   // IV size is 12 bytes/96 bits
   // MAC size is 16 bytes/128 bits
 

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -208,7 +208,7 @@ object Utils extends Logging {
   final val GCM_TAG_LENGTH = 16
   
   def encrypt(data: Array[Byte]): Array[Byte] = {
-    val random = SecureRandom.getInstanceStrong()
+    val random = SecureRandom.getInstance("SHA1PRNG")
     
     // Convert key to SecretKeySpec type
     val key = new Array[Byte](GCM_KEY_LENGTH)


### PR DESCRIPTION
Java places the MAC after the data, while the enclave crypto functions placed it between the IV and the data. This PR changes the enclave implementation to match Java's behavior.

Also, EC2 machines have very low available entropy, causing SecureRandom to hang. This PR instead uses a PRNG.