### PR TITLE
 Add back obliviousness to planner

### DIFF
--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/SecurityLevel.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/SecurityLevel.scala
@@ -25,6 +25,11 @@ sealed trait SecurityLevel {
   def applyTo[T](df: DataFrame): DataFrame
 }
 
+case object Oblivious extends SecurityLevel {
+  override def name: String = "oblivious"
+  override def applyTo[T](df: DataFrame): DataFrame = df.oblivious
+}
+
 case object Encrypted extends SecurityLevel {
   override def name: String = "encrypted"
   override def applyTo[T](df: DataFrame): DataFrame = df.encrypted

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/execution/EncryptedSortExec.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/execution/EncryptedSortExec.scala
@@ -26,6 +26,8 @@ import org.apache.spark.sql.execution.SparkPlan
 case class EncryptedSortExec(order: Seq[SortOrder], child: SparkPlan)
   extends UnaryExecNode with OpaqueOperatorExec {
 
+  override def isOblivious: Boolean = false
+
   override def output: Seq[Attribute] = child.output
 
   override def executeBlocked(): RDD[Block] = {

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -44,6 +44,9 @@ object OpaqueOperators extends Strategy {
     case EncryptedSort(order, child) =>
       EncryptedSortExec(order, planLater(child)) :: Nil
 
+    case ObliviousSort(order, child) =>
+      ObliviousSortExec(order, planLater(child)) :: Nil
+
     case EncryptedJoin(left, right, joinType, condition) =>
       Join(left, right, joinType, condition) match {
         case ExtractEquiJoinKeys(_, leftKeys, rightKeys, condition, _, _) =>
@@ -73,6 +76,9 @@ object OpaqueOperators extends Strategy {
 
     case Encrypt(child) =>
       EncryptExec(planLater(child)) :: Nil
+
+    case Oblivious(child) =>
+      ObliviousExec(planLater(child)) :: Nil
 
     case EncryptedLocalRelation(output, plaintextData) =>
       EncryptedLocalTableScanExec(output, plaintextData) :: Nil

--- a/src/main/scala/org/apache/spark/sql/OpaqueDatasetFunctions.scala
+++ b/src/main/scala/org/apache/spark/sql/OpaqueDatasetFunctions.scala
@@ -18,9 +18,14 @@
 package org.apache.spark.sql
 
 import edu.berkeley.cs.rise.opaque.logical.Encrypt
+import edu.berkeley.cs.rise.opaque.logical.Oblivious
 
 class OpaqueDatasetFunctions[T](ds: Dataset[T]) extends Serializable {
   def encrypted(): DataFrame = {
     Dataset.ofRows(ds.sparkSession, Encrypt(ds.logicalPlan))
+  }
+
+  def oblivious(): DataFrame = {
+    Dataset.ofRows(ds.sparkSession, Oblivious(ds.logicalPlan))
   }
 }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -65,9 +65,9 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
   }
 
   def testObliviousAgainstSpark(name: String)(f: SecurityLevel => Any): Unit = {
-    test(name + " - encrypted") {
-      assert(f(Encrypted) === f(Insecure))
-    }
+    // test(name + " - encrypted") {
+    //   assert(f(Encrypted) === f(Insecure))
+    // }
     test(name + " - oblivious") {
       assert(f(Oblivious) === f(Insecure))
     }
@@ -95,112 +95,112 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     }
   }
 
-  testAgainstSpark("create DataFrame from sequence") { securityLevel =>
-    val data = for (i <- 0 until 5) yield ("foo", i)
-    makeDF(data, securityLevel, "word", "count").collect
-  }
+  // testAgainstSpark("create DataFrame from sequence") { securityLevel =>
+  //   val data = for (i <- 0 until 5) yield ("foo", i)
+  //   makeDF(data, securityLevel, "word", "count").collect
+  // }
 
-  testAgainstSpark("create DataFrame with BinaryType + ByteType") { securityLevel =>
-    val data: Seq[(Array[Byte], Byte)] =
-      Seq((Array[Byte](0.toByte, -128.toByte, 127.toByte), 42.toByte))
-    makeDF(data, securityLevel, "BinaryType", "ByteType").collect
-  }
+  // testAgainstSpark("create DataFrame with BinaryType + ByteType") { securityLevel =>
+  //   val data: Seq[(Array[Byte], Byte)] =
+  //     Seq((Array[Byte](0.toByte, -128.toByte, 127.toByte), 42.toByte))
+  //   makeDF(data, securityLevel, "BinaryType", "ByteType").collect
+  // }
 
-  testAgainstSpark("create DataFrame with CalendarIntervalType + NullType") { securityLevel =>
-    val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 12345), 0.toByte))
-    val schema = StructType(Seq(
-      StructField("CalendarIntervalType", CalendarIntervalType),
-      StructField("NullType", NullType)))
+  // testAgainstSpark("create DataFrame with CalendarIntervalType + NullType") { securityLevel =>
+  //   val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 12345), 0.toByte))
+  //   val schema = StructType(Seq(
+  //     StructField("CalendarIntervalType", CalendarIntervalType),
+  //     StructField("NullType", NullType)))
 
-    securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema)).collect
-  }
+  //   securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema)).collect
+  // }
 
-  testAgainstSpark("create DataFrame with ShortType + TimestampType") { securityLevel =>
-    val data: Seq[(Short, Timestamp)] = Seq((13.toShort, Timestamp.valueOf("2017-12-02 03:04:00")))
-    makeDF(data, securityLevel, "ShortType", "TimestampType").collect
-  }
+  // testAgainstSpark("create DataFrame with ShortType + TimestampType") { securityLevel =>
+  //   val data: Seq[(Short, Timestamp)] = Seq((13.toShort, Timestamp.valueOf("2017-12-02 03:04:00")))
+  //   makeDF(data, securityLevel, "ShortType", "TimestampType").collect
+  // }
 
-  testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
-    val array: Array[Int] = Array(0, -128, 127, 1)
-    val data = Seq(
-      (array, "dog"),
-      (array, "cat"),
-      (array, "ant"))
-    val df = makeDF(data, securityLevel, "array", "string")
-    df.collect
-  }
+  // testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
+  //   val array: Array[Int] = Array(0, -128, 127, 1)
+  //   val data = Seq(
+  //     (array, "dog"),
+  //     (array, "cat"),
+  //     (array, "ant"))
+  //   val df = makeDF(data, securityLevel, "array", "string")
+  //   df.collect
+  // }
 
-  testAgainstSpark("create DataFrame with MapType") { securityLevel =>
-    val map: Map[String, Int] = Map("x" -> 24, "y" -> 25, "z" -> 26)
-    val data = Seq(
-      (map, "dog"),
-      (map, "cat"),
-      (map, "ant"))
-    val df = makeDF(data, securityLevel, "map", "string")
-    df.collect
-  }
+  // testAgainstSpark("create DataFrame with MapType") { securityLevel =>
+  //   val map: Map[String, Int] = Map("x" -> 24, "y" -> 25, "z" -> 26)
+  //   val data = Seq(
+  //     (map, "dog"),
+  //     (map, "cat"),
+  //     (map, "ant"))
+  //   val df = makeDF(data, securityLevel, "map", "string")
+  //   df.collect
+  // }
 
-  testAgainstSpark("filter") { securityLevel =>
-    val df = makeDF(
-      (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
-      securityLevel,
-      "a", "b", "c", "d", "x")
-    df.filter($"x" > lit(10)).collect
-  }
+  // testAgainstSpark("filter") { securityLevel =>
+  //   val df = makeDF(
+  //     (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
+  //     securityLevel,
+  //     "a", "b", "c", "d", "x")
+  //   df.filter($"x" > lit(10)).collect
+  // }
 
-  testAgainstSpark("select") { securityLevel =>
-    val data = for (i <- 0 until 256) yield ("%03d".format(i) * 3, i.toFloat)
-    val df = makeDF(data, securityLevel, "str", "x")
-    df.select($"str").collect
-  }
+  // testAgainstSpark("select") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield ("%03d".format(i) * 3, i.toFloat)
+  //   val df = makeDF(data, securityLevel, "str", "x")
+  //   df.select($"str").collect
+  // }
 
-  testAgainstSpark("select with expressions") { securityLevel =>
-    val df = makeDF(
-      (1 to 20).map(x => (true, "hello world!", 1.0, 2.0f, x)),
-      securityLevel,
-      "a", "b", "c", "d", "x")
-    df.select(
-      $"x" + $"x" * $"x" - $"x",
-      substring($"b", 5, 20),
-      $"x" > $"x",
-      $"x" >= $"x",
-      $"x" <= $"x").collect.toSet
-  }
+  // testAgainstSpark("select with expressions") { securityLevel =>
+  //   val df = makeDF(
+  //     (1 to 20).map(x => (true, "hello world!", 1.0, 2.0f, x)),
+  //     securityLevel,
+  //     "a", "b", "c", "d", "x")
+  //   df.select(
+  //     $"x" + $"x" * $"x" - $"x",
+  //     substring($"b", 5, 20),
+  //     $"x" > $"x",
+  //     $"x" >= $"x",
+  //     $"x" <= $"x").collect.toSet
+  // }
 
-  testAgainstSpark("union") { securityLevel =>
-    val df1 = makeDF(
-      (1 to 20).map(x => (x, x.toString)).reverse,
-      securityLevel,
-      "a", "b")
-    val df2 = makeDF(
-      (1 to 20).map(x => (x, (x + 1).toString)),
-      securityLevel,
-      "a", "b")
-    df1.union(df2).collect.toSet
-  }
+  // testAgainstSpark("union") { securityLevel =>
+  //   val df1 = makeDF(
+  //     (1 to 20).map(x => (x, x.toString)).reverse,
+  //     securityLevel,
+  //     "a", "b")
+  //   val df2 = makeDF(
+  //     (1 to 20).map(x => (x, (x + 1).toString)),
+  //     securityLevel,
+  //     "a", "b")
+  //   df1.union(df2).collect.toSet
+  // }
 
-  testOpaqueOnly("cache") { securityLevel =>
-    def numCached(ds: Dataset[_]): Int =
-      ds.queryExecution.executedPlan.collect {
-        case cached: EncryptedBlockRDDScanExec
-            if cached.rdd.getStorageLevel != StorageLevel.NONE =>
-          cached
-      }.size
+  // testOpaqueOnly("cache") { securityLevel =>
+  //   def numCached(ds: Dataset[_]): Int =
+  //     ds.queryExecution.executedPlan.collect {
+  //       case cached: EncryptedBlockRDDScanExec
+  //           if cached.rdd.getStorageLevel != StorageLevel.NONE =>
+  //         cached
+  //     }.size
 
-    val data = List((1, 3), (1, 4), (1, 5), (2, 4))
-    val df = makeDF(data, securityLevel, "a", "b").cache()
+  //   val data = List((1, 3), (1, 4), (1, 5), (2, 4))
+  //   val df = makeDF(data, securityLevel, "a", "b").cache()
 
-    val agg = df.groupBy($"a").agg(sum("b"))
+  //   val agg = df.groupBy($"a").agg(sum("b"))
 
-    assert(numCached(agg) === 1)
+  //   assert(numCached(agg) === 1)
 
-    val expected = data.groupBy(_._1).mapValues(_.map(_._2).sum)
-    assert(agg.collect.toSet === expected.map(Row.fromTuple).toSet)
-    df.unpersist()
-  }
+  //   val expected = data.groupBy(_._1).mapValues(_.map(_._2).sum)
+  //   assert(agg.collect.toSet === expected.map(Row.fromTuple).toSet)
+  //   df.unpersist()
+  // }
 
   testObliviousAgainstSpark("sort") { securityLevel =>
     val data = Random.shuffle((0 until 256).map(x => (x.toString, x)).toSeq)
@@ -208,283 +208,283 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     df.sort($"x").collect
   }
 
-  testAgainstSpark("sort zero elements") { securityLevel =>
-    val data = Seq.empty[(String, Int)]
-    val df = makeDF(data, securityLevel, "str", "x")
-    df.sort($"x").collect
-  }
+  // testAgainstSpark("sort zero elements") { securityLevel =>
+  //   val data = Seq.empty[(String, Int)]
+  //   val df = makeDF(data, securityLevel, "str", "x")
+  //   df.sort($"x").collect
+  // }
 
-  testAgainstSpark("sort by float") { securityLevel =>
-    val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
-    val df = makeDF(data, securityLevel, "str", "x")
-    df.sort($"x").collect
-  }
+  // testAgainstSpark("sort by float") { securityLevel =>
+  //   val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
+  //   val df = makeDF(data, securityLevel, "str", "x")
+  //   df.sort($"x").collect
+  // }
 
-  testAgainstSpark("sort by string") { securityLevel =>
-    val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
-    val df = makeDF(data, securityLevel, "str", "x")
-    df.sort($"str").collect
-  }
+  // testAgainstSpark("sort by string") { securityLevel =>
+  //   val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
+  //   val df = makeDF(data, securityLevel, "str", "x")
+  //   df.sort($"str").collect
+  // }
 
-  testAgainstSpark("sort by 2 columns") { securityLevel =>
-    val data = Random.shuffle((0 until 256).map(x => (x / 16, x)).toSeq)
-    val df = makeDF(data, securityLevel, "x", "y")
-    df.sort($"x", $"y").collect
-  }
+  // testAgainstSpark("sort by 2 columns") { securityLevel =>
+  //   val data = Random.shuffle((0 until 256).map(x => (x / 16, x)).toSeq)
+  //   val df = makeDF(data, securityLevel, "x", "y")
+  //   df.sort($"x", $"y").collect
+  // }
 
-  testAgainstSpark("join") { securityLevel =>
-    val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
-    val f_data = for (i <- 1 to 256 - 16) yield (i, (i % 16).toString, i * 10)
-    val p = makeDF(p_data, securityLevel, "id", "pk", "x")
-    val f = makeDF(f_data, securityLevel, "id", "fk", "x")
-    p.join(f, $"pk" === $"fk").collect.toSet
-  }
+  // testAgainstSpark("join") { securityLevel =>
+  //   val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
+  //   val f_data = for (i <- 1 to 256 - 16) yield (i, (i % 16).toString, i * 10)
+  //   val p = makeDF(p_data, securityLevel, "id", "pk", "x")
+  //   val f = makeDF(f_data, securityLevel, "id", "fk", "x")
+  //   p.join(f, $"pk" === $"fk").collect.toSet
+  // }
 
-  testAgainstSpark("join on column 1") { securityLevel =>
-    val p_data = for (i <- 1 to 16) yield (i.toString, i * 10)
-    val f_data = for (i <- 1 to 256 - 16) yield ((i % 16).toString, (i * 10).toString, i.toFloat)
-    val p = makeDF(p_data, securityLevel, "pk", "x")
-    val f = makeDF(f_data, securityLevel, "fk", "x", "y")
-    p.join(f, $"pk" === $"fk").collect.toSet
-  }
+  // testAgainstSpark("join on column 1") { securityLevel =>
+  //   val p_data = for (i <- 1 to 16) yield (i.toString, i * 10)
+  //   val f_data = for (i <- 1 to 256 - 16) yield ((i % 16).toString, (i * 10).toString, i.toFloat)
+  //   val p = makeDF(p_data, securityLevel, "pk", "x")
+  //   val f = makeDF(f_data, securityLevel, "fk", "x", "y")
+  //   p.join(f, $"pk" === $"fk").collect.toSet
+  // }
 
-  def abc(i: Int): String = (i % 3) match {
-    case 0 => "A"
-    case 1 => "B"
-    case 2 => "C"
-  }
+  // def abc(i: Int): String = (i % 3) match {
+  //   case 0 => "A"
+  //   case 1 => "B"
+  //   case 2 => "C"
+  // }
 
-  testAgainstSpark("aggregate average") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), i.toDouble)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
+  // testAgainstSpark("aggregate average") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), i.toDouble)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
 
-    words.groupBy("category").agg(avg("price").as("avgPrice"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
+  //   words.groupBy("category").agg(avg("price").as("avgPrice"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
 
-  testAgainstSpark("aggregate count") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
+  // testAgainstSpark("aggregate count") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
 
-    words.groupBy("category").agg(count("category").as("itemsInCategory"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
+  //   words.groupBy("category").agg(count("category").as("itemsInCategory"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
 
-  testAgainstSpark("aggregate first") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
+  // testAgainstSpark("aggregate first") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
 
-    words.groupBy("category").agg(first("category").as("firstInCategory"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
+  //   words.groupBy("category").agg(first("category").as("firstInCategory"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
 
-  testAgainstSpark("aggregate last") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
+  // testAgainstSpark("aggregate last") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
 
-    words.groupBy("category").agg(last("category").as("lastInCategory"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
+  //   words.groupBy("category").agg(last("category").as("lastInCategory"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
 
-  testAgainstSpark("aggregate max") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
+  // testAgainstSpark("aggregate max") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
 
-    words.groupBy("category").agg(max("price").as("maxPrice"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
+  //   words.groupBy("category").agg(max("price").as("maxPrice"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
 
-  testAgainstSpark("aggregate min") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
+  // testAgainstSpark("aggregate min") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
 
-    words.groupBy("category").agg(min("price").as("minPrice"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
+  //   words.groupBy("category").agg(min("price").as("minPrice"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
 
-  testAgainstSpark("aggregate sum") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "word", "count")
+  // testAgainstSpark("aggregate sum") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "word", "count")
 
-    words.groupBy("word").agg(sum("count").as("totalCount"))
-      .collect.sortBy { case Row(word: String, _) => word }
-  }
+  //   words.groupBy("word").agg(sum("count").as("totalCount"))
+  //     .collect.sortBy { case Row(word: String, _) => word }
+  // }
 
-  testAgainstSpark("aggregate on multiple columns") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (abc(i), 1, 1.0f)
-    val words = makeDF(data, securityLevel, "str", "x", "y")
+  // testAgainstSpark("aggregate on multiple columns") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (abc(i), 1, 1.0f)
+  //   val words = makeDF(data, securityLevel, "str", "x", "y")
 
-    words.groupBy("str").agg(sum("y").as("totalY"), avg("x").as("avgX"))
-      .collect.sortBy { case Row(str: String, _, _) => str }
-  }
+  //   words.groupBy("str").agg(sum("y").as("totalY"), avg("x").as("avgX"))
+  //     .collect.sortBy { case Row(str: String, _, _) => str }
+  // }
 
-  testOpaqueOnly("global aggregate") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "word", "count")
-    val result = words.agg(sum("count").as("totalCount"))
-  }
+  // testOpaqueOnly("global aggregate") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "word", "count")
+  //   val result = words.agg(sum("count").as("totalCount"))
+  // }
 
-  testAgainstSpark("contains") { securityLevel =>
-    val data = for (i <- 0 until 256) yield(i.toString, abc(i))
-    val df = makeDF(data, securityLevel, "word", "abc")
-    df.filter($"word".contains(lit("1"))).collect
-  }
+  // testAgainstSpark("contains") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield(i.toString, abc(i))
+  //   val df = makeDF(data, securityLevel, "word", "abc")
+  //   df.filter($"word".contains(lit("1"))).collect
+  // }
 
-  testAgainstSpark("year") { securityLevel =>
-    val data = Seq(Tuple2(1, new java.sql.Date(new java.util.Date().getTime())))
-    val df = makeDF(data, securityLevel, "id", "date")
-    df.select(year($"date")).collect
-  }
+  // testAgainstSpark("year") { securityLevel =>
+  //   val data = Seq(Tuple2(1, new java.sql.Date(new java.util.Date().getTime())))
+  //   val df = makeDF(data, securityLevel, "id", "date")
+  //   df.select(year($"date")).collect
+  // }
 
-  testOpaqueOnly("save and load with explicit schema") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val df = makeDF(data, securityLevel, "id", "word", "count")
-    val path = Utils.createTempDir()
-    path.delete()
-    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
-    try {
-      val df2 = spark.read
-        .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
-        .schema(df.schema)
-        .load(path.toString)
-      assert(df.collect.toSet === df2.collect.toSet)
-      assert(df.groupBy("word").agg(sum("count")).collect.toSet
-        === df2.groupBy("word").agg(sum("count")).collect.toSet)
-    } finally {
-      Utils.deleteRecursively(path)
-    }
-  }
+  // testOpaqueOnly("save and load with explicit schema") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val df = makeDF(data, securityLevel, "id", "word", "count")
+  //   val path = Utils.createTempDir()
+  //   path.delete()
+  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+  //   try {
+  //     val df2 = spark.read
+  //       .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
+  //       .schema(df.schema)
+  //       .load(path.toString)
+  //     assert(df.collect.toSet === df2.collect.toSet)
+  //     assert(df.groupBy("word").agg(sum("count")).collect.toSet
+  //       === df2.groupBy("word").agg(sum("count")).collect.toSet)
+  //   } finally {
+  //     Utils.deleteRecursively(path)
+  //   }
+  // }
 
-  testOpaqueOnly("save and load without schema") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val df = makeDF(data, securityLevel, "id", "word", "count")
-    val path = Utils.createTempDir()
-    path.delete()
-    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
-    try {
-      val df2 = spark.read
-        .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
-        .load(path.toString)
-      assert(df.collect.toSet === df2.collect.toSet)
-      assert(df.groupBy("word").agg(sum("count")).collect.toSet
-        === df2.groupBy("word").agg(sum("count")).collect.toSet)
-    } finally {
-      Utils.deleteRecursively(path)
-    }
-  }
+  // testOpaqueOnly("save and load without schema") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val df = makeDF(data, securityLevel, "id", "word", "count")
+  //   val path = Utils.createTempDir()
+  //   path.delete()
+  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+  //   try {
+  //     val df2 = spark.read
+  //       .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
+  //       .load(path.toString)
+  //     assert(df.collect.toSet === df2.collect.toSet)
+  //     assert(df.groupBy("word").agg(sum("count")).collect.toSet
+  //       === df2.groupBy("word").agg(sum("count")).collect.toSet)
+  //   } finally {
+  //     Utils.deleteRecursively(path)
+  //   }
+  // }
 
-  testOpaqueOnly("load from SQL with explicit schema") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val df = makeDF(data, securityLevel, "id", "word", "count")
-    val path = Utils.createTempDir()
-    path.delete()
-    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+  // testOpaqueOnly("load from SQL with explicit schema") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val df = makeDF(data, securityLevel, "id", "word", "count")
+  //   val path = Utils.createTempDir()
+  //   path.delete()
+  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
 
-    try {
-      spark.sql(s"""
-        |CREATE TEMPORARY VIEW df2
-        |(${df.schema.toDDL})
-        |USING edu.berkeley.cs.rise.opaque.EncryptedSource
-        |OPTIONS (
-        |  path "${path}"
-        |)""".stripMargin)
-      val df2 = spark.sql(s"""
-        |SELECT * FROM df2
-        |""".stripMargin)
+  //   try {
+  //     spark.sql(s"""
+  //       |CREATE TEMPORARY VIEW df2
+  //       |(${df.schema.toDDL})
+  //       |USING edu.berkeley.cs.rise.opaque.EncryptedSource
+  //       |OPTIONS (
+  //       |  path "${path}"
+  //       |)""".stripMargin)
+  //     val df2 = spark.sql(s"""
+  //       |SELECT * FROM df2
+  //       |""".stripMargin)
 
-      assert(df.collect.toSet === df2.collect.toSet)
-    } finally {
-      spark.catalog.dropTempView("df2")
-      Utils.deleteRecursively(path)
-    }
-  }
+  //     assert(df.collect.toSet === df2.collect.toSet)
+  //   } finally {
+  //     spark.catalog.dropTempView("df2")
+  //     Utils.deleteRecursively(path)
+  //   }
+  // }
 
-  testOpaqueOnly("load from SQL without schema") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val df = makeDF(data, securityLevel, "id", "word", "count")
-    val path = Utils.createTempDir()
-    path.delete()
-    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+  // testOpaqueOnly("load from SQL without schema") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val df = makeDF(data, securityLevel, "id", "word", "count")
+  //   val path = Utils.createTempDir()
+  //   path.delete()
+  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
 
-    try {
-      spark.sql(s"""
-        |CREATE TEMPORARY VIEW df2
-        |USING edu.berkeley.cs.rise.opaque.EncryptedSource
-        |OPTIONS (
-        |  path "${path}"
-        |)""".stripMargin)
-      val df2 = spark.sql(s"""
-        |SELECT * FROM df2
-        |""".stripMargin)
+  //   try {
+  //     spark.sql(s"""
+  //       |CREATE TEMPORARY VIEW df2
+  //       |USING edu.berkeley.cs.rise.opaque.EncryptedSource
+  //       |OPTIONS (
+  //       |  path "${path}"
+  //       |)""".stripMargin)
+  //     val df2 = spark.sql(s"""
+  //       |SELECT * FROM df2
+  //       |""".stripMargin)
 
-      assert(df.collect.toSet === df2.collect.toSet)
-    } finally {
-      spark.catalog.dropTempView("df2")
-      Utils.deleteRecursively(path)
-    }
-  }
+  //     assert(df.collect.toSet === df2.collect.toSet)
+  //   } finally {
+  //     spark.catalog.dropTempView("df2")
+  //     Utils.deleteRecursively(path)
+  //   }
+  // }
 
-  testAgainstSpark("SQL API") { securityLevel =>
-    val df = makeDF(
-      (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
-      securityLevel,
-      "a", "b", "c", "d", "x")
-    df.createTempView("df")
-    try {
-      spark.sql("SELECT * FROM df WHERE x > 10").collect
-    } finally {
-      spark.catalog.dropTempView("df")
-    }
-  }
+  // testAgainstSpark("SQL API") { securityLevel =>
+  //   val df = makeDF(
+  //     (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
+  //     securityLevel,
+  //     "a", "b", "c", "d", "x")
+  //   df.createTempView("df")
+  //   try {
+  //     spark.sql("SELECT * FROM df WHERE x > 10").collect
+  //   } finally {
+  //     spark.catalog.dropTempView("df")
+  //   }
+  // }
 
-  testOpaqueOnly("cast error") { securityLevel =>
-    val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 12345), 0.toByte))
-    val schema = StructType(Seq(
-      StructField("CalendarIntervalType", CalendarIntervalType),
-      StructField("NullType", NullType)))
-    val df = securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema))
-    // Trigger an Opaque exception by attempting an unsupported cast: CalendarIntervalType to
-    // StringType
-    val e = intercept[SparkException] {
-      withLoggingOff {
-        df.select($"CalendarIntervalType".cast(StringType)).collect
-      }
-    }
-    assert(e.getCause.isInstanceOf[OpaqueException])
-  }
+  // testOpaqueOnly("cast error") { securityLevel =>
+  //   val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 12345), 0.toByte))
+  //   val schema = StructType(Seq(
+  //     StructField("CalendarIntervalType", CalendarIntervalType),
+  //     StructField("NullType", NullType)))
+  //   val df = securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema))
+  //   // Trigger an Opaque exception by attempting an unsupported cast: CalendarIntervalType to
+  //   // StringType
+  //   val e = intercept[SparkException] {
+  //     withLoggingOff {
+  //       df.select($"CalendarIntervalType".cast(StringType)).collect
+  //     }
+  //   }
+  //   assert(e.getCause.isInstanceOf[OpaqueException])
+  // }
 
-  testAgainstSpark("least squares") { securityLevel =>
-    val answer = LeastSquares.query(spark, securityLevel, "tiny", numPartitions).collect
-    answer
-  }
+  // testAgainstSpark("least squares") { securityLevel =>
+  //   val answer = LeastSquares.query(spark, securityLevel, "tiny", numPartitions).collect
+  //   answer
+  // }
 
-  testOpaqueOnly("pagerank") { securityLevel =>
-    PageRank.run(spark, securityLevel, "256", numPartitions)
-  }
+  // testOpaqueOnly("pagerank") { securityLevel =>
+  //   PageRank.run(spark, securityLevel, "256", numPartitions)
+  // }
 
-  testAgainstSpark("TPC-H 9") { securityLevel =>
-    TPCH.tpch9(spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
-  }
+  // testAgainstSpark("TPC-H 9") { securityLevel =>
+  //   TPCH.tpch9(spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
+  // }
 
-  testAgainstSpark("big data 1") { securityLevel =>
-    BigDataBenchmark.q1(spark, securityLevel, "tiny", numPartitions).collect
-  }
+  // testAgainstSpark("big data 1") { securityLevel =>
+  //   BigDataBenchmark.q1(spark, securityLevel, "tiny", numPartitions).collect
+  // }
 
-  testAgainstSpark("big data 2") { securityLevel =>
-    BigDataBenchmark.q2(spark, securityLevel, "tiny", numPartitions).collect
-      .map { case Row(a: String, b: Double) => (a, b.toFloat) }
-      .sortBy(_._1)
-      .map {
-        case (str: String, f: Float) => (str, "%.2f".format(f))
-      }
-  }
+  // testAgainstSpark("big data 2") { securityLevel =>
+  //   BigDataBenchmark.q2(spark, securityLevel, "tiny", numPartitions).collect
+  //     .map { case Row(a: String, b: Double) => (a, b.toFloat) }
+  //     .sortBy(_._1)
+  //     .map {
+  //       case (str: String, f: Float) => (str, "%.2f".format(f))
+  //     }
+  // }
 
-  testAgainstSpark("big data 3") { securityLevel =>
-    BigDataBenchmark.q3(spark, securityLevel, "tiny", numPartitions).collect
-  }
+  // testAgainstSpark("big data 3") { securityLevel =>
+  //   BigDataBenchmark.q3(spark, securityLevel, "tiny", numPartitions).collect
+  // }
 
   def makeDF[A <: Product : scala.reflect.ClassTag : scala.reflect.runtime.universe.TypeTag](
     data: Seq[A], securityLevel: SecurityLevel, columnNames: String*): DataFrame =

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -64,6 +64,15 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     }
   }
 
+  def testObliviousAgainstSpark(name: String)(f: SecurityLevel => Any): Unit = {
+    test(name + " - encrypted") {
+      assert(f(Encrypted) === f(Insecure))
+    }
+    test(name + " - oblivious") {
+      assert(f(Oblivious) === f(Insecure))
+    }
+  }
+
   def testOpaqueOnly(name: String)(f: SecurityLevel => Unit): Unit = {
     test(name + " - encrypted") {
       f(Encrypted)
@@ -193,7 +202,7 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     df.unpersist()
   }
 
-  testAgainstSpark("sort") { securityLevel =>
+  testObliviousAgainstSpark("sort") { securityLevel =>
     val data = Random.shuffle((0 until 256).map(x => (x.toString, x)).toSeq)
     val df = makeDF(data, securityLevel, "str", "x")
     df.sort($"x").collect


### PR DESCRIPTION
This PR adds back obliviousness to the planner and uses it in the "sort" test in OpaqueOperatorTests, allowing debugging column sort.

Currently this test gives a segfault, which you can debug by commenting out all the other tests except the "sort" test (I already did this in the PR), then running `build/sbt sgx-gdb`.

This segfault appears to be because you're passing null as the sort_order argument of the `EnclaveColumnSort` JNI call (in ObliviousSortExec.ColumnSortPad and .ColumnSortFilter). The sort_order argument of ObliviousSortExec.NewColumnSort should be passed instead.